### PR TITLE
Modif du yaml pour effectivement basculer sur la 9.3 !!!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 jdk:
   - oraclejdk8
 services: postgresql
-addons: 
-  postgresql:"9.3"
+addons:
+  postgresql: 9.3
 before_script:
   - dropdb --if-exists sc_lint_test
   - psql -c 'create database sc_lint_test;' -U postgres


### PR DESCRIPTION
LA conf du yaml était pas bonne, elle était pas prise en compte, mais grâce à ce post, c'est bon, ça passe :

https://github.com/travis-ci/travis-ci/issues/1721

dans le build travis, tu verras remonter la version :

`Starting PostgreSQL v9.3...`... qui te dit que tout est bon :+1: 